### PR TITLE
fix: update clone URL to microsoft/promptkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You → bootstrap.md → LLM reads manifest → selects components → assembled
 Clone the repo and point Copilot at the bootstrap prompt:
 
 ```bash
-git clone https://github.com/Alan-Jowett/promptkit.git
+git clone https://github.com/microsoft/promptkit.git
 cd promptkit
 
 # Copilot reads bootstrap.md, discovers the library via manifest.yaml,


### PR DESCRIPTION
Update the git clone URL in README.md from the old personal repo (\Alan-Jowett/promptkit\) to the new org location (\microsoft/promptkit\).