### PR TITLE
Fix manifest protocol drift and add CI validation

### DIFF
--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) PromptKit Contributors
+
+name: Validate Manifest
+
+on:
+  push:
+    paths:
+      - 'manifest.yaml'
+      - 'templates/**'
+      - 'tests/validate-manifest.py'
+  pull_request:
+    paths:
+      - 'manifest.yaml'
+      - 'templates/**'
+      - 'tests/validate-manifest.py'
+
+jobs:
+  validate-manifest:
+    name: Check manifest ↔ template protocol sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate manifest protocols
+        run: python tests/validate-manifest.py

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -227,7 +227,7 @@ templates:
       description: >
         Generate a design document that addresses a requirements document.
       persona: software-architect
-      protocols: [anti-hallucination]
+      protocols: [anti-hallucination, self-verification]
       format: design-doc
       pipeline_position: 2
       requires: requirements-document
@@ -237,7 +237,7 @@ templates:
       description: >
         Generate a validation plan covering all requirements.
       persona: systems-engineer
-      protocols: [anti-hallucination]
+      protocols: [anti-hallucination, self-verification]
       format: validation-plan
       pipeline_position: 3
       requires: requirements-document
@@ -249,7 +249,7 @@ templates:
         Investigate a bug from a problem description. Apply root cause
         analysis and produce an investigation report.
       persona: systems-engineer
-      protocols: [anti-hallucination, root-cause-analysis]
+      protocols: [anti-hallucination, self-verification, operational-constraints, root-cause-analysis]
       format: investigation-report
 
     - name: investigate-security
@@ -258,7 +258,7 @@ templates:
         Security audit of code or a system component. Systematic
         vulnerability analysis with severity classification.
       persona: security-auditor
-      protocols: [anti-hallucination, security-vulnerability]
+      protocols: [anti-hallucination, self-verification, operational-constraints, security-vulnerability]
       format: investigation-report
 
   code-analysis:
@@ -268,7 +268,7 @@ templates:
         Thorough code review for correctness, safety, security,
         and maintainability. Supports additional analysis protocols.
       persona: systems-engineer
-      protocols: [anti-hallucination]
+      protocols: [anti-hallucination, self-verification, operational-constraints]
       format: investigation-report
 
   planning:
@@ -278,7 +278,7 @@ templates:
         Decompose a project into an actionable implementation plan
         with tasks, dependencies, and risk assessment.
       persona: software-architect
-      protocols: [anti-hallucination]
+      protocols: [anti-hallucination, self-verification]
 
     - name: plan-refactoring
       path: templates/plan-refactoring.md
@@ -286,7 +286,7 @@ templates:
         Plan a safe, incremental refactoring with step-by-step
         changes that maintain correctness at each step.
       persona: software-architect
-      protocols: [anti-hallucination]
+      protocols: [anti-hallucination, self-verification]
 
   contribution:
     - name: extend-library

--- a/tests/validate-manifest.py
+++ b/tests/validate-manifest.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) PromptKit Contributors
+
+"""Validate that manifest.yaml protocol lists match template frontmatter.
+
+This script prevents drift between the protocol lists declared in
+manifest.yaml (which bootstrap.md reads to assemble prompts) and the
+protocol lists in each template's YAML frontmatter (the source of truth
+for which protocols a template actually uses).
+
+Exit code 0 = all protocol lists match.
+Exit code 1 = one or more mismatches detected.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Lightweight YAML helpers (avoids external dependencies)
+# ---------------------------------------------------------------------------
+
+def parse_yaml_frontmatter(text: str) -> dict[str, object] | None:
+    """Extract the YAML frontmatter block between --- delimiters.
+
+    Returns a minimal dict with the keys we care about (protocols),
+    or None if no frontmatter is found.
+    """
+    match = re.search(r"^---\s*\n(.*?)\n---", text, re.DOTALL | re.MULTILINE)
+    if not match:
+        return None
+    block = match.group(1)
+    protocols: list[str] = []
+    in_protocols = False
+    for line in block.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("protocols:"):
+            in_protocols = True
+            # Handle inline list: protocols: [a, b, c]
+            inline = re.search(r"\[(.+)]", stripped)
+            if inline:
+                protocols = [p.strip().strip("'\"") for p in inline.group(1).split(",")]
+                in_protocols = False
+            continue
+        if in_protocols:
+            if stripped.startswith("- "):
+                protocols.append(stripped[2:].strip().strip("'\""))
+            else:
+                in_protocols = False
+    return {"protocols": protocols}
+
+
+def parse_manifest_templates(manifest_text: str) -> dict[str, list[str]]:
+    """Parse manifest.yaml and return {template_name: [protocol_short_names]}.
+
+    Uses a line-by-line state machine to avoid a PyYAML dependency.
+    """
+    templates: dict[str, list[str]] = {}
+    current_name: str | None = None
+    for line in manifest_text.splitlines():
+        stripped = line.strip()
+        # Detect template name
+        name_match = re.match(r"^-\s*name:\s*(.+)", stripped)
+        if name_match:
+            # Only capture names under the templates section; we rely on
+            # the fact that template entries have a 'path' starting with
+            # 'templates/'.  We'll validate that below.
+            current_name = name_match.group(1).strip().strip("'\"")
+            continue
+        # Detect path to confirm this is a template entry
+        if current_name and stripped.startswith("path:"):
+            path_val = stripped.split(":", 1)[1].strip().strip("'\"")
+            if not path_val.startswith("templates/"):
+                current_name = None
+            continue
+        # Detect protocols line
+        if current_name and stripped.startswith("protocols:"):
+            inline = re.search(r"\[(.+)]", stripped)
+            if inline:
+                protocols = [p.strip().strip("'\"") for p in inline.group(1).split(",")]
+                templates[current_name] = protocols
+            current_name = None
+            continue
+    return templates
+
+
+def protocol_short_name(full_path: str) -> str:
+    """Extract the short protocol name from a category/name path.
+
+    E.g. 'guardrails/anti-hallucination' -> 'anti-hallucination'
+         'anti-hallucination'            -> 'anti-hallucination'
+    """
+    return full_path.rsplit("/", 1)[-1]
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate(repo_root: Path) -> list[str]:
+    """Compare manifest protocol lists against template frontmatter.
+
+    Returns a list of human-readable error strings (empty = success).
+    """
+    manifest_path = repo_root / "manifest.yaml"
+    templates_dir = repo_root / "templates"
+    errors: list[str] = []
+
+    if not manifest_path.exists():
+        errors.append(f"manifest.yaml not found at {manifest_path}")
+        return errors
+
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    manifest_templates = parse_manifest_templates(manifest_text)
+
+    if not manifest_templates:
+        errors.append("No templates found in manifest.yaml")
+        return errors
+
+    # Check every template file in the templates directory
+    template_files = sorted(templates_dir.glob("*.md"))
+    frontmatter_names: set[str] = set()
+
+    for tmpl_file in template_files:
+        tmpl_text = tmpl_file.read_text(encoding="utf-8")
+        fm = parse_yaml_frontmatter(tmpl_text)
+        if fm is None:
+            errors.append(f"{tmpl_file.name}: no YAML frontmatter found")
+            continue
+
+        # Derive the template name from frontmatter or filename
+        name_match = re.search(r"^name:\s*(.+)", tmpl_text.split("---")[1], re.MULTILINE)
+        if name_match:
+            tmpl_name = name_match.group(1).strip().strip("'\"")
+        else:
+            tmpl_name = tmpl_file.stem
+        frontmatter_names.add(tmpl_name)
+
+        # Get protocols from frontmatter (normalize to short names)
+        fm_protocols = sorted(set(protocol_short_name(p) for p in fm["protocols"]))
+
+        # Get protocols from manifest
+        if tmpl_name not in manifest_templates:
+            errors.append(
+                f"{tmpl_name}: present in templates/ but missing from manifest.yaml"
+            )
+            continue
+
+        manifest_protocols = sorted(set(manifest_templates[tmpl_name]))
+
+        if fm_protocols != manifest_protocols:
+            fm_only = sorted(set(fm_protocols) - set(manifest_protocols))
+            manifest_only = sorted(set(manifest_protocols) - set(fm_protocols))
+            parts = [f"{tmpl_name}: protocol mismatch"]
+            if fm_only:
+                parts.append(f"  in frontmatter but not manifest: {', '.join(fm_only)}")
+            if manifest_only:
+                parts.append(f"  in manifest but not frontmatter: {', '.join(manifest_only)}")
+            errors.append("\n".join(parts))
+
+    # Check for templates in manifest that don't have a corresponding file
+    for manifest_name in sorted(manifest_templates):
+        if manifest_name not in frontmatter_names:
+            expected_file = templates_dir / f"{manifest_name}.md"
+            if not expected_file.exists():
+                errors.append(
+                    f"{manifest_name}: listed in manifest.yaml but "
+                    f"no file found at templates/{manifest_name}.md"
+                )
+
+    return errors
+
+
+def main() -> int:
+    # Allow passing repo root as an argument; default to script's grandparent
+    if len(sys.argv) > 1:
+        repo_root = Path(sys.argv[1])
+    else:
+        repo_root = Path(__file__).resolve().parent.parent
+
+    errors = validate(repo_root)
+
+    if errors:
+        print(f"FAIL: manifest.yaml validation failed ({len(errors)} error(s)):\n")
+        for err in errors:
+            print(f"  - {err}")
+        print(
+            "\nManifest protocol lists must match template YAML frontmatter.\n"
+            "See CONTRIBUTING.md for the convention."
+        )
+        return 1
+
+    print("OK: manifest.yaml protocols match all template frontmatter.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fix protocol lists in `manifest.yaml` for **7 templates** where the manifest was missing protocols declared in the template YAML frontmatter, and add a CI check to prevent future drift.

## Problem

Several templates declare protocols in their YAML frontmatter that weren't reflected in `manifest.yaml`. Since `bootstrap.md` reads from the manifest to assemble prompts, users get prompts missing important quality gates like `self-verification` and `operational-constraints`.

The issue reported 3 affected templates; a full audit found **4 more**.

## Changes

### Immediate fix — `manifest.yaml`

| Template | Added protocols |
|---|---|
| `author-design-doc` | `self-verification` |
| `author-validation-plan` | `self-verification` |
| `investigate-bug` | `self-verification`, `operational-constraints` |
| `investigate-security` | `self-verification`, `operational-constraints` |
| `review-code` | `self-verification`, `operational-constraints` |
| `plan-implementation` | `self-verification` |
| `plan-refactoring` | `self-verification` |

### Systemic prevention

- **`tests/validate-manifest.py`** — Zero-dependency Python script that parses both `manifest.yaml` and every template's YAML frontmatter, compares protocol lists, and exits non-zero on mismatch. Catches drift in both directions (manifest-only and frontmatter-only protocols).
- **`.github/workflows/validate-manifest.yml`** — CI workflow that runs the check on every push/PR touching `manifest.yaml`, `templates/`, or the script itself.

Closes #11