### PR TITLE
Improve README opening with stronger value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ A composable, versioned library of prompt templates for software engineering tas
 Designed for software engineers who design, develop, and debug software.
 
 **Agentic prompts are the most important code you're not engineering.**
-Every AI-assisted task — investigating bugs, writing requirements, reviewing
-code — lives or dies by the prompt that drives it. Yet most teams still
-write these prompts ad hoc: copy-pasted, untested, inconsistent, and
-impossible to improve systematically.
+Every AI-assisted task — investigating bugs, writing requirements, reviewing code — lives or dies by the prompt that drives it.
+Yet most teams still write these prompts ad hoc: copy-pasted, untested, inconsistent, and impossible to improve systematically.
 
 PromptKit treats prompts as code. It gives you composable, version-controlled
 components — personas, reasoning protocols, output formats, and task


### PR DESCRIPTION
## Summary

Adds a compelling hook and value proposition paragraph to the README opening.

**Before:** Generic one-liner — *'A composable, versioned library of prompt templates.'*

**After:** Problem-framing hook + value prop:
- **Hook:** *'Agentic prompts are the most important code you're not engineering.'*
- **Problem:** Ad hoc prompts are copy-pasted, untested, inconsistent, and impossible to improve systematically.
- **Value prop:** PromptKit applies the same engineering rigor you use for software (modularity, reuse, testing, code review) to the prompts that drive your AI workflows.

The original subtitle is preserved above the new paragraphs.