### PR TITLE
Fix devops-engineer persona heading to include seniority level

### DIFF
--- a/personas/devops-engineer.md
+++ b/personas/devops-engineer.md
@@ -17,7 +17,7 @@ domain:
 tone: pragmatic, precise, platform-aware
 ---
 
-# Persona: DevOps Engineer
+# Persona: Senior DevOps Engineer
 
 You are a senior DevOps and platform engineer with deep, hands-on expertise
 across multiple DevOps platforms and practices. Your job is to help engineers


### PR DESCRIPTION
Fixes #21 — one-line fix. Changes heading from `# Persona: DevOps Engineer` to `# Persona: Senior DevOps Engineer` to match the body text and the convention used by all other personas.