### PR TITLE
Add Sonde specification audit case study

### DIFF
--- a/docs/case-studies/sonde-specification-audit.md
+++ b/docs/case-studies/sonde-specification-audit.md
@@ -305,11 +305,15 @@ design:
 
 **Semantic test gaps (6 issues, ~45 individual gaps).** Tests exist and
 are linked to requirements, but don't verify deeply enough. For example:
-issue #357 found that protocol tests check output exists but not that
-randomness is cryptographic, CBOR is deterministic, or HMAC state is
-isolated. Issue #354 found 11 node tests that check outcomes but not
-timing/ordering constraints ("MUST wait for X before Y"). Issue #359
-found requirements with happy-path tests but no negative tests.
+Sonde issue
+[#357](https://github.com/alan-jowett/sonde/issues/357) found that
+protocol tests check output exists but not that randomness is
+cryptographic, CBOR is deterministic, or HMAC state is isolated. Sonde
+[#354](https://github.com/alan-jowett/sonde/issues/354) found 11 node
+tests that check outcomes but not timing/ordering constraints ("MUST
+wait for X before Y"). Sonde
+[#359](https://github.com/alan-jowett/sonde/issues/359) found
+requirements with happy-path tests but no negative tests.
 
 *Why missed:* The trifecta audit checks "does a test case exist for this
 requirement?" (D2). It does not read test procedures to judge whether
@@ -317,9 +321,11 @@ they're thorough enough. That's D7 territory, which it only spot-checks
 at the acceptance-criteria level.
 
 **Domain-specific safety gaps (4 issues, ~50+ individual gaps).** These
-require deep understanding of the BPF interpreter's safety model. Issue
-#330 found 28 tagged register safety invariants with zero test coverage.
-Issue #334 found 8 BPF helper trust boundary gaps. These come from
+require deep understanding of the BPF interpreter's safety model. Sonde
+[#330](https://github.com/alan-jowett/sonde/issues/330) found 28 tagged
+register safety invariants with zero test coverage. Sonde
+[#334](https://github.com/alan-jowett/sonde/issues/334) found 8 BPF
+helper trust boundary gaps. These come from
 `safe-bpf-interpreter.md` — a separate specification not included in
 any component's trifecta.
 
@@ -328,7 +334,8 @@ outside the trifecta are invisible to it.
 
 **Cross-component integration (1 issue, 5 gaps).** The end-to-end BLE
 onboarding flow across gateway + modem + pairing tool was never
-integration-tested (#361).
+integration-tested (Sonde
+[#361](https://github.com/alan-jowett/sonde/issues/361)).
 
 *Why missed:* The trifecta audit examines each component independently.
 Cross-component flows are invisible to per-component audits.


### PR DESCRIPTION
## Summary

Adds a case study based on a real-world audit of the [Sonde](https://github.com/alan-jowett/sonde) IoT runtime — 5 components, 260 requirements, 60 findings from one reusable prompt.

## What makes this case study different

Unlike the existing \udit-traceability\ case study (hypothetical auth service), this is based on **real audit results** from a production project, with a **manual vs. PromptKit comparison**:

| Metric | Value |
|--------|-------|
| Components audited | 5 (protocol, node, gateway, modem, BLE tool) |
| Requirements analyzed | 260 |
| Total findings | 60 |
| Findings already known (manual audit) | 17 (29%) |
| Findings partially known | 13 (22%) |
| **Net-new findings** | **29 (49%)** |

## Key insight

Manual audit and PromptKit audit found **different types of issues**:
- **Manual** excelled at validation/test gaps (D2, D7)
- **PromptKit** excelled at design traceability gaps (D1, D6)
- The two are **complementary, not competing**

## Systemic finding

BLE pairing design was missing from 3 of 5 component design docs — a pattern invisible to per-component manual review but immediately obvious when the same prompt surfaced it independently in modem (45% gap), node (32% gap), and gateway (30% gap).
