### PR TITLE
Support supplementary specification documents in trifecta audit

### DIFF
--- a/protocols/reasoning/traceability-audit.md
+++ b/protocols/reasoning/traceability-audit.md
@@ -56,12 +56,13 @@ content for the missing document.
    - Identifiers or section numbers that the core documents cite
    - Assumptions that bear on the requirements or design
 
-5. **External reference check** — scan the requirements and design
-   documents for references to external specifications (by name, URL,
-   or document ID) that are not included in the provided document set.
-   Record each missing reference so it can be reported in the coverage
-   summary. This catches the case where a component's full specification
-   surface is larger than the provided trifecta.
+5. **External reference check** — scan the provided documents
+   (requirements, design if present, validation plan) for references to
+   external specifications (by name, URL, or document ID) that are not
+   included in the provided document set. Record each missing reference
+   so it can be reported in the coverage summary. This catches the case
+   where a component's full specification surface is larger than the
+   provided trifecta.
 
 ## Phase 2: Forward Traceability (Requirements → Downstream)
 

--- a/templates/audit-traceability.md
+++ b/templates/audit-traceability.md
@@ -21,7 +21,7 @@ params:
   requirements_doc: "The requirements document content"
   design_doc: "The design document content (optional — omit for a two-document audit)"
   validation_plan: "The validation plan content"
-  additional_specs: "Optional supplementary specifications that requirements may reference (e.g., security model, protocol spec, API spec). Provide content or 'none'"
+  additional_specs: "Optional supplementary specifications that requirements may reference (e.g., security model, protocol spec, API spec). Omit or leave empty if none"
   focus_areas: "Optional narrowing — e.g., 'security requirements only', 'API contracts' (default: audit all)"
   audience: "Who will read the audit report — e.g., 'engineering leads', 'project stakeholders'"
 input_contract:
@@ -57,7 +57,7 @@ requirements, design, and validation artifacts.
 **Validation Plan**:
 {{validation_plan}}
 
-**Supplementary Specifications** (if provided):
+**Supplementary Specifications** (if provided — ignore if empty):
 {{additional_specs}}
 
 **Focus Areas**: {{focus_areas}}


### PR DESCRIPTION
Closes #47

Adds an optional `additional_specs` parameter so users can provide supplementary specifications that requirements reference but aren't part of the core trifecta.

**Changes:**
- **Template**: New `additional_specs` param and input section, plus instruction for handling external references
- **Protocol Phase 1**: New steps to inventory supplementary specs and scan for references to unprovided external documents
- **Protocol Phase 6**: Coverage summary now reports missing external references

**Motivation:** The Sonde case study found 4 ad-hoc audit issues from `safe-bpf-interpreter.md` — a spec outside all component trifectas. The audit had no way to know it was missing relevant context. Now it will either use the supplementary spec (if provided) or flag that the core documents reference external specs not included in the audit.
