### PR TITLE
Rename SPL references to PromptKit throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ promptkit/
 │   └── content/             # Bundled content (generated, gitignored)
 └── tests/                   # Prompt unit tests
     ├── references/          # Known-good reference prompts
-    └── generated/           # SPL-generated prompts for comparison
+    └── generated/           # PromptKit-generated prompts for comparison
 ```
 
 ## Template Format

--- a/TESTING.md
+++ b/TESTING.md
@@ -4,7 +4,7 @@
 ---
 name: prompt-testing
 description: >
-  Methodology for unit testing SPL-generated prompts by comparing
+  Methodology for unit testing PromptKit-generated prompts by comparing
   them against known-good reference prompts. Defines a structured
   gap analysis process for validating prompt quality.
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,7 @@ The Markdown body contains expertise areas and behavioral constraints like
 headings should include seniority level (e.g., "Senior Systems Engineer").
 
 **Available:** systems-engineer, security-auditor, software-architect,
-devops-engineer, reverse-engineer, spl-contributor
+devops-engineer, reverse-engineer, promptkit-contributor
 
 ### Layer 2: Protocols
 

--- a/docs/case-studies/author-agent-instructions.md
+++ b/docs/case-studies/author-agent-instructions.md
@@ -33,7 +33,7 @@ npx promptkit assemble author-agent-instructions \
 
 ### What Gets Assembled
 
-The prompt composes the `spl-contributor` persona with anti-hallucination
+The prompt composes the `promptkit-contributor` persona with anti-hallucination
 and self-verification protocols, plus the `agent-instructions` format. The
 template body instructs the LLM to:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ For the full composition model and assembly internals, see the
 | Audit for security | `investigate-security` | security-auditor |
 | Set up CI/CD | `author-pipeline` | devops-engineer |
 | Generate release notes | `author-release` | devops-engineer |
-| Create agent instructions | `author-agent-instructions` | spl-contributor |
+| Create agent instructions | `author-agent-instructions` | promptkit-contributor |
 | Extract requirements from code | `reverse-engineer-requirements` | reverse-engineer |
 
 Run `npx promptkit list` for the full list with descriptions.

--- a/formats/multi-artifact.md
+++ b/formats/multi-artifact.md
@@ -62,7 +62,7 @@ For machine-readable artifacts (JSONL, JSON, CSV):
 
 For reports, summaries, and analysis documents:
 
-- Follow the relevant SPL format (investigation-report, requirements-doc, etc.)
+- Follow the relevant PromptKit format (investigation-report, requirements-doc, etc.)
   OR define a custom structure in the task template.
 - Every claim MUST reference evidence by identifier from the structured
   data artifact (e.g., "see call site CS-042 in boundary_callsites.jsonl").

--- a/formats/promptkit-pull-request.md
+++ b/formats/promptkit-pull-request.md
@@ -2,15 +2,15 @@
 <!-- Copyright (c) PromptKit Contributors -->
 
 ---
-name: spl-pull-request
+name: promptkit-pull-request
 type: format
 description: >
-  Output format for SPL contributions. Produces PR-ready component
+  Output format for PromptKit contributions. Produces PR-ready component
   files, a manifest update, and a pull request description.
-produces: spl-contribution
+produces: promptkit-contribution
 ---
 
-# Format: SPL Pull Request
+# Format: PromptKit Pull Request
 
 The output MUST be a complete, PR-ready set of files and a pull
 request description. Every file must be ready to commit — no

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,10 +27,10 @@ personas:
       Staff software architect. System design, API contracts, tradeoff
       analysis, and long-term maintainability.
 
-  - name: spl-contributor
-    path: personas/spl-contributor.md
+  - name: promptkit-contributor
+    path: personas/promptkit-contributor.md
     description: >
-      SPL contribution guide. Understands the library's architecture,
+      PromptKit contribution guide. Understands the library's architecture,
       conventions, and quality standards. Guides contributors through
       designing and building new components.
 
@@ -123,10 +123,10 @@ protocols:
         preserving structural integrity, numbering, cross-references,
         and internal consistency.
 
-    - name: spl-design
-      path: protocols/reasoning/spl-design.md
+    - name: promptkit-design
+      path: protocols/reasoning/promptkit-design.md
       description: >
-        Reasoning protocol for designing new SPL components. Scoping,
+        Reasoning protocol for designing new PromptKit components. Scoping,
         component type selection, dependency analysis, and convention
         compliance.
 
@@ -199,11 +199,11 @@ formats:
       (structured data, reports, coverage logs). Defines artifact manifests,
       per-artifact schemas, and cross-artifact consistency rules.
 
-  - name: spl-pull-request
-    path: formats/spl-pull-request.md
-    produces: spl-contribution
+  - name: promptkit-pull-request
+    path: formats/promptkit-pull-request.md
+    produces: promptkit-contribution
     description: >
-      Output format for SPL contributions. Produces PR-ready component
+      Output format for PromptKit contributions. Produces PR-ready component
       files, manifest update, and pull request description.
 
   - name: pipeline-spec
@@ -399,7 +399,7 @@ templates:
         agent skill files. For GitHub Copilot, produces individual
         .github/instructions/*.instructions.md files with applyTo targeting.
         Also supports Claude Code (CLAUDE.md) and Cursor (.cursorrules).
-      persona: spl-contributor
+      persona: promptkit-contributor
       protocols: [anti-hallucination, self-verification]
       format: agent-instructions
 
@@ -407,11 +407,11 @@ templates:
     - name: extend-library
       path: templates/extend-library.md
       description: >
-        Guide a contributor through designing and building new SPL
+        Guide a contributor through designing and building new PromptKit
         components. Interactive workflow producing PR-ready files.
-      persona: spl-contributor
-      protocols: [anti-hallucination, self-verification, spl-design]
-      format: spl-pull-request
+      persona: promptkit-contributor
+      protocols: [anti-hallucination, self-verification, promptkit-design]
+      format: promptkit-pull-request
 
   devops:
     - name: author-pipeline

--- a/personas/promptkit-contributor.md
+++ b/personas/promptkit-contributor.md
@@ -2,7 +2,7 @@
 <!-- Copyright (c) PromptKit Contributors -->
 
 ---
-name: spl-contributor
+name: promptkit-contributor
 description: >
   An expert in PromptKit's architecture, conventions,
   and quality standards. Guides contributors through designing and
@@ -14,7 +14,7 @@ domain:
 tone: helpful, precise, quality-focused
 ---
 
-# Persona: SPL Contributor Guide
+# Persona: PromptKit Contributor Guide
 
 You are an expert contributor to PromptKit. You
 deeply understand the library's architecture, conventions, and quality
@@ -23,7 +23,7 @@ new library components.
 
 Your expertise spans:
 
-- **SPL architecture**: the 5-layer composition model (personas, protocols,
+- **PromptKit architecture**: the 5-layer composition model (personas, protocols,
   formats, taxonomies, templates) and how they compose.
 - **Conventions**: YAML frontmatter schema, `{{param}}` placeholders,
   kebab-case naming, SPDX headers, input/output contracts, and pipeline

--- a/protocols/reasoning/promptkit-design.md
+++ b/protocols/reasoning/promptkit-design.md
@@ -2,17 +2,17 @@
 <!-- Copyright (c) PromptKit Contributors -->
 
 ---
-name: spl-design
+name: promptkit-design
 type: reasoning
 description: >
-  Reasoning protocol for designing new SPL components. Walks through
+  Reasoning protocol for designing new PromptKit components. Walks through
   scoping, component type selection, dependency analysis, and
   convention compliance before generating any files.
 applicable_to:
   - extend-library
 ---
 
-# Protocol: SPL Component Design
+# Protocol: PromptKit Component Design
 
 Apply this protocol when designing a new component for
 PromptKit. Execute all phases before generating files.

--- a/templates/author-agent-instructions.md
+++ b/templates/author-agent-instructions.md
@@ -8,7 +8,7 @@ description: >
   agent skill files. For GitHub Copilot, produces individual
   .github/instructions/*.instructions.md files with applyTo targeting.
   Also supports Claude Code (CLAUDE.md) and Cursor (.cursorrules).
-persona: spl-contributor
+persona: promptkit-contributor
 protocols:
   - guardrails/anti-hallucination
   - guardrails/self-verification

--- a/templates/extend-library.md
+++ b/templates/extend-library.md
@@ -5,22 +5,22 @@
 name: extend-library
 mode: interactive
 description: >
-  Guide a contributor through designing and building new SPL components.
+  Guide a contributor through designing and building new PromptKit components.
   Uses the interactive-design workflow: reason through the design,
   then generate PR-ready files. Produces all necessary components
   (persona, protocol, format, taxonomy, template) and a manifest update.
-persona: spl-contributor
+persona: promptkit-contributor
 protocols:
   - guardrails/anti-hallucination
   - guardrails/self-verification
-  - reasoning/spl-design
-format: spl-pull-request
+  - reasoning/promptkit-design
+format: promptkit-pull-request
 params:
   use_case: "What the new prompt template should help users accomplish"
   context: "Any additional context — target domain, example workflows, existing tools"
 input_contract: null
 output_contract:
-  type: spl-contribution
+  type: promptkit-contribution
   description: >
     A complete set of PR-ready files (components + manifest update)
     and a pull request description.
@@ -53,7 +53,7 @@ and conventions:
 
 ### Step 2: Interactive Design (Phase 1)
 
-**Apply the spl-design protocol.** Work interactively with the user:
+**Apply the promptkit-design protocol.** Work interactively with the user:
 
 1. **Clarify the use case.** Ask specific questions:
    - What task does the user want to support?
@@ -81,7 +81,7 @@ Once the user confirms the design:
 
 1. **Generate each component file** following CONTRIBUTING.md conventions.
 2. **Generate the manifest update** showing exactly what to add.
-3. **Generate the PR description** following the spl-pull-request format.
+3. **Generate the PR description** following the promptkit-pull-request format.
 4. **Apply the self-verification protocol** — check every file against
    the CONTRIBUTING.md quality checklist.
 


### PR DESCRIPTION
SPL (Standard Prompt Library) was the project's original name. The rename to PromptKit happened but the acronym was missed in component names, filenames, and prose. This cleans it up completely.

**File renames (3):**
- `personas/spl-contributor.md` → `promptkit-contributor.md`
- `protocols/reasoning/spl-design.md` → `promptkit-design.md`
- `formats/spl-pull-request.md` → `promptkit-pull-request.md`

**Component names (4):**
- `spl-contributor` → `promptkit-contributor`
- `spl-design` → `promptkit-design`
- `spl-pull-request` → `promptkit-pull-request`
- `spl-contribution` → `promptkit-contribution`

**Text updates:** 13 files, zero SPL references remain.

**Validation:** `tests/validate-manifest.py` passes.
