### PR TITLE
chore: bump version to 0.2.0 for release

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alan-jowett/promptkit",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Composable prompt toolkit for software engineers. Assemble task-specific prompts from reusable personas, protocols, formats, and templates.",
   "license": "MIT",
   "repository": {

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,7 +6,7 @@
 # The bootstrap prompt reads this manifest to discover available
 # personas, protocols, formats, and task templates.
 
-version: "0.1.0"
+version: "0.2.0"
 
 personas:
   - name: systems-engineer


### PR DESCRIPTION
Closes #53

Bumps version from 0.1.0 to 0.2.0 in:
- `cli/package.json`
- `cli/package-lock.json`
- `manifest.yaml`

The `v0.2.0` git tag already exists. This PR aligns the npm manifest so the publish workflow produces the correct version. Once merged, tag the release commit and the GitHub Actions publish workflow will handle npm.
