### PR TITLE
Add self-audit prompt for convention compliance checking

### DIFF
--- a/tests/self-audit-prompt.md
+++ b/tests/self-audit-prompt.md
@@ -5,7 +5,7 @@
 
 Use this prompt to audit PromptKit's own components against
 CONTRIBUTING.md conventions. Feed it to an LLM with access to the
-repository, or paste the manifest + component frontmatter as context.
+repository, or paste the manifest and full component files as context.
 
 ## How to Run
 
@@ -88,6 +88,8 @@ For each template in `manifest.yaml`:
 - If `taxonomies` is declared, do the referenced taxonomies exist?
 - Does the body have an **Inputs section** listing all `{{param}}`
   placeholders from frontmatter `params`?
+- Does the body have an **Instructions section** with numbered,
+  specific steps?
 - Does the body have a **Quality checklist** section?
 - **Param usage**: For each key in frontmatter `params`, does
   `{{key}}` appear in the template body? Flag params that are declared
@@ -95,7 +97,9 @@ For each template in `manifest.yaml`:
 
 #### 5. Taxonomy Compliance
 
-For each taxonomy in `manifest.yaml`:
+For each taxonomy in `manifest.yaml` (taxonomy conventions are
+documented in `docs/architecture.md`, not CONTRIBUTING.md — cite
+that file for taxonomy-specific findings):
 - Does the file exist at the declared `path`?
 - Does `name` match the filename (kebab-case, without `.md`)?
 - Does it have `name`, `type: taxonomy`, `description`, `domain`?


### PR DESCRIPTION
Adds a self-audit prompt that checks PromptKit's own components against CONTRIBUTING.md conventions.

## What it checks

- All 5 component types: personas, protocols, formats, taxonomies, templates
- Required frontmatter fields per component type
- Cross-reference integrity (manifest ↔ files ↔ frontmatter)
- Param usage: declared params must appear as `{{param}}` in template body
- Convention compliance (naming, structure, quality checklists)

## First run results

Found 3 findings on v0.2.0:
- **F-001 (Medium)**: 11 templates declare `audience` param but never use `{{audience}}` in the body — silently ignored input
- **F-002 (Low)**: `interactive-design` manifest says `persona: configurable` — not a real persona name
- **F-003 (Low)**: `interactive-design` uses `{{persona}}` in frontmatter only, not body

## How to run

```bash
copilot -i "Read and execute tests/self-audit-prompt.md"
```

Or with Claude Code:
```bash
claude "Read and execute tests/self-audit-prompt.md"
```
