### PR TITLE
Add cross-component integration audit template (#48)

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -189,6 +189,15 @@ protocols:
         test implementations and classifies findings using the
         specification-drift taxonomy (D11–D13).
 
+    - name: integration-audit
+      path: protocols/reasoning/integration-audit.md
+      description: >
+        Systematic protocol for auditing cross-component integration
+        points. Maps integration flows across component boundaries,
+        verifies interface contracts, and checks integration test
+        coverage. Classifies findings using the specification-drift
+        taxonomy (D14–D16).
+
     - name: rfc-extraction
       path: protocols/reasoning/rfc-extraction.md
       description: >
@@ -319,10 +328,11 @@ taxonomies:
     path: taxonomies/specification-drift.md
     domain: specification-traceability
     description: >
-      Classification scheme (D1-D7) for specification drift across
-      requirements, design, and validation artifacts. Covers untraced
-      requirements, orphaned design decisions, assumption drift, and
-      acceptance criteria mismatch. Extensible to D8+ for code/test audits.
+      Classification scheme (D1-D16) for specification drift across
+      requirements, design, validation, code, test, and integration
+      artifacts. Covers untraced requirements, orphaned design decisions,
+      assumption drift, coverage failures, code/test compliance gaps,
+      and cross-component integration drift.
 
 templates:
   document-authoring:
@@ -413,6 +423,19 @@ templates:
       taxonomies: [specification-drift]
       format: investigation-report
       requires: [requirements-document, validation-plan]
+
+    - name: audit-integration-compliance
+      path: templates/audit-integration-compliance.md
+      description: >
+        Audit cross-component integration points against an integration
+        specification and per-component specs. Detects unspecified
+        integration flows, interface contract mismatches, and untested
+        integration paths.
+      persona: specification-analyst
+      protocols: [anti-hallucination, self-verification, operational-constraints, integration-audit]
+      taxonomies: [specification-drift]
+      format: investigation-report
+      requires: requirements-document
 
   standards:
     - name: extract-rfc-requirements

--- a/protocols/reasoning/integration-audit.md
+++ b/protocols/reasoning/integration-audit.md
@@ -1,0 +1,195 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) PromptKit Contributors -->
+
+---
+name: integration-audit
+type: reasoning
+description: >
+  Systematic protocol for auditing cross-component integration points.
+  Maps integration flows across component boundaries, verifies interface
+  contracts, and checks integration test coverage. Classifies findings
+  using the specification-drift taxonomy (D14–D16).
+applicable_to:
+  - audit-integration-compliance
+---
+
+# Protocol: Integration Audit
+
+Apply this protocol when auditing cross-component integration points
+against an integration specification and per-component specs. The goal
+is to find every gap in how components interact — unspecified flows,
+mismatched interface contracts, and untested integration paths.
+
+Per-component audits (traceability, code-compliance, test-compliance)
+verify that each component's artifacts are internally consistent. This
+protocol addresses the gaps that are invisible to those audits: the
+seams between components.
+
+## Phase 1: Integration Specification Inventory
+
+Extract the integration-level claims from the integration specification.
+
+1. **Integration flows** — for each end-to-end flow, extract:
+   - The flow ID and description (e.g., "BLE onboarding: pairing tool →
+     gateway → modem → cloud registration")
+   - The ordered sequence of components involved
+   - The handoff points between components (data, control, events)
+   - The end-to-end preconditions and postconditions
+   - Success criteria and failure/rollback behavior
+
+2. **Interface contracts** — for each component boundary, extract:
+   - The interface ID (API, protocol, event, shared resource)
+   - The producing component and consuming component
+   - Data formats, schemas, and message types exchanged
+   - Error handling expectations (who detects, who recovers)
+   - Sequencing and timing constraints
+   - Version compatibility requirements
+
+3. **Integration test expectations** — extract:
+   - Any integration or E2E test cases referenced in the spec
+   - Coverage expectations (which flows are tested, which are
+     explicitly deferred)
+   - Environment or infrastructure assumptions for integration testing
+
+## Phase 2: Component Specification Inventory
+
+Survey each component's specification to understand its view of the
+integration boundary.
+
+1. **For each component**, extract:
+   - The external interfaces it declares (APIs it exposes, events it
+     emits, protocols it speaks)
+   - The dependencies it declares (APIs it calls, events it consumes,
+     services it requires)
+   - Assumptions about the behavior of other components
+   - Error handling at component boundaries (what errors it propagates
+     vs. handles internally)
+
+2. **Build a component interaction matrix**: a table with components
+   as rows and columns. Each cell records the declared interface
+   between the pair (from each side's perspective). Blank cells
+   indicate components with no declared interaction.
+
+Do NOT assume that two components interact just because the integration
+spec describes a flow involving both. Check each component's own spec
+for evidence that it knows about the interaction.
+
+## Phase 3: Flow Traceability (Integration Spec → Component Specs)
+
+For each integration flow in the integration specification:
+
+1. **Trace through each component** in the flow's sequence:
+   - Does the component's spec acknowledge its role in this flow?
+   - Does the component's spec describe the required inputs it
+     receives from the upstream component?
+   - Does the component's spec describe the outputs it produces for
+     the downstream component?
+   - Are the preconditions at each handoff compatible with the
+     postconditions of the previous step?
+
+2. **Check end-to-end coherence**:
+   - Do the component-level specs, taken together, cover the full flow
+     from start to finish?
+   - Are there gaps in the sequence where no component claims
+     responsibility for a step?
+   - Are there error handling gaps — a failure mode described at one
+     boundary but not handled by the receiving component?
+
+3. **Classify the result**:
+   - **FULLY TRACED**: Every step in the flow traces to specific
+     requirements in component specs.
+   - **PARTIALLY TRACED**: Some steps trace, others do not. Flag
+     gaps as D14_UNSPECIFIED_INTEGRATION_FLOW with evidence of what
+     is missing.
+   - **NOT TRACED**: The flow appears in the integration spec but is
+     absent from component specs. Flag as D14 with confidence High.
+
+## Phase 4: Interface Contract Verification
+
+For each interface between components:
+
+1. **Compare both sides' descriptions** of the interface:
+   - Data formats: Does the producer's output schema match the
+     consumer's expected input schema?
+   - Error codes and error handling: Does the consumer handle the
+     errors the producer can emit? Does the consumer expect errors
+     the producer never emits?
+   - Sequencing: Do both sides agree on message ordering, handshake
+     sequences, and state machine transitions?
+   - Timing: Are timeout values, retry policies, and rate limits
+     compatible?
+
+2. **Check against the integration spec**:
+   - Does the integration spec's description of the interface match
+     what both component specs describe?
+   - Are there constraints in the integration spec that neither
+     component spec mentions?
+
+3. **Flag mismatches** as D15_INTERFACE_CONTRACT_MISMATCH with:
+   - Both sides' descriptions (quoted from their respective specs)
+   - The specific incompatibility
+   - Impact assessment (will the mismatch cause runtime failure,
+     data corruption, silent degradation, or is it cosmetic?)
+
+## Phase 5: Integration Test Coverage
+
+For each integration flow and interface contract:
+
+1. **Search for integration/E2E tests** that exercise the flow:
+   - Look for tests that involve multiple components
+   - Look for tests that verify handoff behavior at boundaries
+   - Look for tests that exercise error/rollback paths across
+     boundaries
+
+2. **Assess test coverage**:
+   - Does the test exercise the full flow end-to-end, or only
+     a subset of the steps?
+   - Does the test verify the interface contract (data formats,
+     error handling, sequencing), or only the happy path?
+   - Are failure modes tested — what happens when a component in the
+     middle of the flow fails?
+
+3. **Flag gaps** as D16_UNTESTED_INTEGRATION_PATH with:
+   - The flow or interface that lacks test coverage
+   - What specifically is untested (full flow, error path, specific
+     handoff)
+   - The linked integration spec section and component specs
+
+If no integration test code is provided, report all flows as
+D16 candidates with confidence Low and note that test code was not
+available for analysis.
+
+## Phase 6: Classification and Reporting
+
+Classify every finding using the specification-drift taxonomy.
+
+1. Assign exactly one drift label (D14, D15, or D16) to each finding.
+2. Assign severity using the taxonomy's severity guidance.
+3. For each finding, provide:
+   - The drift label and short title
+   - The integration spec location and relevant component spec
+     locations
+   - Evidence: what the integration spec says, what each component
+     spec says (or doesn't)
+   - Impact: what could go wrong at runtime
+   - Recommended resolution (which spec or test needs updating)
+4. Order findings primarily by severity, then by taxonomy ranking
+   within each severity tier.
+
+## Phase 7: Coverage Summary
+
+After reporting individual findings, produce aggregate metrics:
+
+1. **Flow traceability rate**: integration flows fully traced to
+   component specs / total integration flows.
+2. **Interface contract alignment**: interfaces with matching
+   descriptions on both sides / total interfaces.
+3. **Integration test coverage**: flows with at least one integration
+   test / total flows. Also report: flows with error path coverage /
+   total flows.
+4. **Cross-component gap count**: total handoff points where no
+   component claims responsibility.
+5. **Overall assessment**: a summary judgment of integration
+   specification health (e.g., "High alignment — 2 interface
+   mismatches" or "Low alignment — systemic gaps in flow
+   traceability").

--- a/taxonomies/specification-drift.md
+++ b/taxonomies/specification-drift.md
@@ -14,6 +14,7 @@ applicable_to:
   - audit-traceability
   - audit-code-compliance
   - audit-test-compliance
+  - audit-integration-compliance
 ---
 
 # Taxonomy: Specification Drift
@@ -269,21 +270,92 @@ compliance drift type because it creates false confidence. Severity
 should be assessed based on the gap between what is asserted and what
 should be asserted.
 
+## Integration Compliance Labels
+
+### D14_UNSPECIFIED_INTEGRATION_FLOW
+
+A cross-component integration flow is described in the integration
+specification but is not reflected in one or more component specs.
+
+**Pattern**: The integration spec describes an end-to-end flow that
+traverses components A → B → C. Component B's specification does not
+mention its role in this flow, does not describe receiving input from
+A, or does not describe producing output for C. The flow exists at
+the system level but has a gap at the component level.
+
+**Risk**: The flow may be implemented by convention or tribal knowledge
+but is not contractually specified. Changes to component B may break
+the flow without any specification-level signal. Per-component audits
+will not detect this because no component's spec claims responsibility
+for the missing step.
+
+**Severity guidance**: High when the flow is safety-critical, involves
+data integrity, or is a core user-facing workflow. Medium for
+operational or diagnostic flows. Assess based on what breaks if the
+gap causes a runtime failure.
+
+### D15_INTERFACE_CONTRACT_MISMATCH
+
+Two components describe the same interface differently in their
+respective specifications.
+
+**Pattern**: Component A's spec says it produces output in format X
+with error codes {E1, E2}. Component B's spec says it consumes input
+in format Y with error codes {E2, E3}. The interface exists on both
+sides but the descriptions are incompatible — different data formats,
+different error sets, different sequencing assumptions, or different
+timing constraints.
+
+**Risk**: Runtime failures at the integration boundary — data
+corruption, unhandled errors, deadlocks, or silent degradation.
+Per-component audits see each side as internally consistent; the
+mismatch is only visible when comparing both sides.
+
+**Severity guidance**: Critical when the mismatch involves data
+integrity, security properties, or will cause deterministic runtime
+failure. High when it involves error handling or sequencing that may
+cause intermittent failures. Medium for cosmetic or logging
+differences that do not affect correctness.
+
+### D16_UNTESTED_INTEGRATION_PATH
+
+A cross-component integration flow or interface contract is specified
+but has no corresponding integration or end-to-end test.
+
+**Pattern**: The integration spec describes flow F-NNN traversing
+components A → B → C. No integration test exercises this flow
+end-to-end. Individual component tests may test A's output and B's
+input separately, but no test verifies the handoff between them under
+realistic conditions.
+
+**Risk**: Defects at integration boundaries will not be caught until
+production. Per-component test-compliance audits will show full
+coverage within each component, masking the integration gap. This is
+the integration-level equivalent of D11 (unimplemented test case).
+
+**Severity guidance**: High when the flow is safety-critical or
+involves data that crosses trust boundaries. Medium for well-understood
+interfaces with stable contracts. Note: flows explicitly marked as
+"manual integration test" or "deferred" in the integration spec are
+excluded from D16 findings and reported only in the coverage summary.
+
 ## Ranking Criteria
 
 Within a given severity level, order findings by impact on specification
 integrity:
 
 1. **Highest risk**: D6 (constraint violation in design), D7 (illusory
-   test coverage), D10 (constraint violation in code), and D13
-   (assertion mismatch) — these indicate active conflicts between
-   artifacts.
+   test coverage), D10 (constraint violation in code), D13
+   (assertion mismatch), and D15 (interface contract mismatch) —
+   these indicate active conflicts between artifacts.
 2. **High risk**: D2 (untested requirement), D5 (assumption drift),
-   D8 (unimplemented requirement), and D12 (untested acceptance
-   criterion) — these indicate silent gaps that will surface late.
+   D8 (unimplemented requirement), D12 (untested acceptance
+   criterion), and D14 (unspecified integration flow) — these
+   indicate silent gaps that will surface late.
 3. **Medium risk**: D1 (untraced requirement), D3 (orphaned design),
-   D9 (undocumented behavior), and D11 (unimplemented test case) —
-   these indicate incomplete traceability that needs human resolution.
+   D9 (undocumented behavior), D11 (unimplemented test case), and
+   D16 (untested integration path) — these indicate incomplete
+   traceability that needs human resolution.
 4. **Lowest risk**: D4 (orphaned test case) — effort misdirection but
    no safety or correctness impact.
 

--- a/templates/audit-integration-compliance.md
+++ b/templates/audit-integration-compliance.md
@@ -1,0 +1,144 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- Copyright (c) PromptKit Contributors -->
+
+---
+name: audit-integration-compliance
+description: >
+  Audit cross-component integration points against an integration
+  specification and per-component specs. Detects unspecified integration
+  flows, interface contract mismatches, and untested integration paths.
+  Classifies findings using the specification-drift taxonomy (D14–D16).
+persona: specification-analyst
+protocols:
+  - guardrails/anti-hallucination
+  - guardrails/self-verification
+  - guardrails/operational-constraints
+  - reasoning/integration-audit
+taxonomies:
+  - specification-drift
+format: investigation-report
+params:
+  project_name: "Name of the system being audited"
+  integration_spec: "System-level integration specification — E2E flows, interface contracts, integration test expectations"
+  component_specs: "Per-component requirements and/or design documents (multiple components)"
+  test_code: "Integration/E2E test code (optional — omit if unavailable)"
+  focus_areas: "Optional narrowing — e.g., 'BLE onboarding flow only', 'gateway ↔ modem interface' (default: audit all)"
+  audience: "Who will read the audit report — e.g., 'system architects', 'integration test team'"
+input_contract:
+  type: requirements-document
+  description: >
+    A system-level integration specification describing cross-component
+    flows, interface contracts, and integration test expectations.
+    Per-component requirements and/or design documents for each
+    component involved in integration flows. Optionally, integration
+    or E2E test code.
+output_contract:
+  type: investigation-report
+  description: >
+    An investigation report classifying integration compliance findings
+    using the D14–D16 taxonomy, with cross-component coverage metrics
+    and remediation recommendations.
+---
+
+# Task: Audit Integration Compliance
+
+You are tasked with auditing cross-component integration points against
+an integration specification to detect **integration compliance drift**
+— gaps between what was specified for cross-component behavior and what
+the component specifications and tests actually cover.
+
+This audit addresses a blind spot in per-component audits: flows that
+span component boundaries. A system where every component passes its
+own traceability, code-compliance, and test-compliance audits can still
+have critical integration gaps — unspecified handoffs, mismatched
+interface contracts, and untested end-to-end paths.
+
+## Inputs
+
+**Project Name**: {{project_name}}
+
+**Integration Specification**:
+{{integration_spec}}
+
+**Component Specifications**:
+{{component_specs}}
+
+**Integration/E2E Test Code** (if provided):
+{{test_code}}
+
+**Focus Areas**: {{focus_areas}}
+
+## Instructions
+
+1. **Apply the integration-audit protocol.** Execute all phases in
+   order. This is the core methodology — do not skip phases.
+
+2. **Classify every finding** using the specification-drift taxonomy
+   (D14–D16). Every finding MUST have exactly one drift label, a
+   severity, evidence, and a recommended resolution. Include specific
+   locations in the integration spec AND the relevant component
+   spec(s).
+
+3. **If test code is not provided**, skip Phase 5 (integration test
+   coverage) but report all integration flows as D16 candidates with
+   confidence Low and a note that test code was not available for
+   analysis.
+
+4. **If focus areas are specified**, perform the full inventories
+   (Phases 1–2) but restrict detailed tracing (Phases 3–5) to
+   flows and interfaces related to the focus areas.
+
+5. **Apply the anti-hallucination protocol.** Every finding must cite
+   specific locations in the integration spec and component specs. Do
+   NOT invent interface contracts or assume components interact in
+   ways not described in their specs. If a component's spec does not
+   mention an interface that the integration spec assumes, that is a
+   D14 finding — do not fabricate the missing specification.
+
+6. **Apply the operational-constraints protocol.** Focus on the
+   integration boundaries — the handoff points between components.
+   Do not deeply audit each component's internal spec consistency
+   (that is the job of per-component audit templates).
+
+7. **Format the output** according to the investigation-report format.
+   Map the protocol's output to the report structure:
+   - Phase 1–2 inventories → Investigation Scope (section 3)
+   - Phases 3–5 findings → Findings (section 4), one F-NNN per issue
+   - Phase 6 classification → Finding severity and categorization
+   - Phase 7 coverage summary → Executive Summary (section 1) and
+     a "Coverage Metrics" subsection in Root Cause Analysis (section 5)
+   - Recommended resolutions → Remediation Plan (section 6)
+
+8. **Quality checklist** — before finalizing, verify:
+   - [ ] Every integration flow from the integration spec appears in
+         at least one finding or is confirmed as fully traced
+   - [ ] Every interface between components is checked for contract
+         alignment
+   - [ ] Every finding has a specific drift label (D14, D15, or D16)
+   - [ ] Every finding cites integration spec AND component spec
+         locations
+   - [ ] D14 findings identify which component spec is missing the
+         flow or handoff
+   - [ ] D15 findings quote both sides of the mismatched interface
+         contract
+   - [ ] D16 findings identify what integration test is missing and
+         what flow it should cover
+   - [ ] Coverage metrics are calculated from actual counts
+   - [ ] The executive summary is understandable without reading the
+         full report
+
+## Non-Goals
+
+- Do NOT perform per-component audits — this template audits
+  integration boundaries only. Use `audit-traceability`,
+  `audit-code-compliance`, or `audit-test-compliance` for
+  per-component audits.
+- Do NOT modify any specifications or test code — report findings only.
+- Do NOT assess whether the integration specification is correct for
+  the domain — only whether component specs and tests faithfully
+  implement what it describes.
+- Do NOT fabricate interface contracts or integration flows that are
+  not described in the provided documents.
+- Do NOT deeply analyze component internals — focus on the boundaries
+  where components interact.
+- Do NOT expand scope beyond the provided documents and code.


### PR DESCRIPTION
## Summary

Adds a new `audit-integration-compliance` template that audits cross-component integration points against an integration specification and per-component specs. This addresses the blind spot found in the Sonde case study where 5 independent per-component audits missed E2E BLE onboarding gaps across gateway + modem + pairing tool.

## New Components

### Template: `audit-integration-compliance`
- **Persona:** `specification-analyst` (reused)
- **Protocols:** anti-hallucination, self-verification, operational-constraints, integration-audit (new)
- **Taxonomy:** `specification-drift` (extended with D14–D16)
- **Format:** `investigation-report` (reused)
- **Params:** `project_name`, `integration_spec`, `component_specs`, `test_code` (optional), `focus_areas`, `audience`

### Protocol: `integration-audit` (7 phases)
1. Integration specification inventory
2. Component specification inventory
3. Flow traceability (integration spec → component specs)
4. Interface contract verification
5. Integration test coverage
6. Classification and reporting
7. Coverage summary

### Taxonomy: specification-drift D14–D16
- **D14_UNSPECIFIED_INTEGRATION_FLOW** — cross-component flow not reflected in component specs
- **D15_INTERFACE_CONTRACT_MISMATCH** — two components describe the same interface differently
- **D16_UNTESTED_INTEGRATION_PATH** — specified integration flow has no E2E test

Ranking criteria updated to include D14–D16.

## Files Changed

| File | Change |
|------|--------|
| `protocols/reasoning/integration-audit.md` | New protocol |
| `templates/audit-integration-compliance.md` | New template |
| `taxonomies/specification-drift.md` | Extended with D14–D16 + updated ranking |
| `manifest.yaml` | New protocol + template entries, updated taxonomy description |

## Validation

- `tests/validate-manifest.py` passes ✅

Closes #48