### PR TITLE
docs: add Pass 3 to sonde case study and editorial consistency fixes

### DIFF
--- a/docs/case-studies/sonde-specification-audit.md
+++ b/docs/case-studies/sonde-specification-audit.md
@@ -517,8 +517,8 @@ With fixes merged, a third audit pass was run using the
 `audit-code-compliance` prompt — re-assembled against the updated
 specs as a **code→spec** audit (the reverse direction from Pass 2).
 The same one-prompt, parallel
-execution approach was used: four agents, one per component, each
-using a separate repo clone.
+execution approach was used: four agents for the four code-bearing
+components audited in Pass 3, each using a separate repo clone.
 
 ```bash
 npx @alan-jowett/promptkit assemble audit-code-compliance \
@@ -526,7 +526,7 @@ npx @alan-jowett/promptkit assemble audit-code-compliance \
   -p requirements_doc="$(cat docs/<component>-requirements.md)" \
   -p design_doc="$(cat docs/<component>-design.md)" \
   -p validation_plan="$(cat docs/<component>-validation.md)" \
-  -p source_code="<component source tree>" \
+  -p code_context="<component source tree>" \
   -p focus_areas="all" \
   -o <component>-code-compliance-audit.md
 ```


### PR DESCRIPTION
Documents the Pass 3 post-fix code→spec audit and performs an editorial pass for consistency across all three passes. No findings changed.

### Pass 3 content

The case study now covers the third audit pass — a code→spec audit run after boot-test fixes were merged (PRs #441, #443). This pass found 33 findings, including spec drift introduced by the fixes themselves (e.g., timeout changes and retry logic added without updating specs). The document now reflects the full three-pass arc: spec↔spec → spec→code → code→spec.

### Editorial fixes

- **Subtitle**: updated stale counts (two→three passes, 114→147 findings, 217→260 requirements)
- **Takeaways section**: moved from before Pass 3 to after it — the section referenced `147 findings` and `three passes` before the reader had seen Pass 3
- **Prompt name**: `sonde-audit-code-compliance` → `audit-code-compliance` (consistent with the template name used everywhere else); removed misleading `newly generated` qualifier
- **Summary table**: `3 prompts` → `2 prompts` (only `audit-traceability` and `audit-code-compliance` were used)
- **Plural fix**: `Finding driven directly` → `Findings driven directly` (three items follow)
- **Paragraph break**: separated node/gateway analysis into distinct paragraphs
- **Sentence join**: fixed missing line break between sentences in Pass 3 narrative
