### PR TITLE
Remove phantom applicable_to reference in finding-classification protocol

### DIFF
--- a/protocols/reasoning/finding-classification.md
+++ b/protocols/reasoning/finding-classification.md
@@ -9,8 +9,7 @@ description: >
   review comments, audit results) against a known taxonomy or
   pattern catalog. Performs three-way classification with
   justification, confidence analysis, and catalog update proposals.
-applicable_to:
-  - classify-findings
+applicable_to: []
 ---
 
 # Protocol: Finding Classification


### PR DESCRIPTION
## Summary

The \inding-classification\ protocol's \pplicable_to\ field references a template \classify-findings\ that does not exist in the manifest or on disk. This was discovered during a full manifest ↔ component consistency audit.

## Change

Set \pplicable_to: []\ until a consuming template is added.

## Context

Found via audit: 109 components checked across 8 consistency dimensions. This was the only real inconsistency (the remaining items are pre-existing convention gaps around optional \input_contract\ fields).