### PR TITLE
Refresh README for engineering lifecycle triad

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ prompt based on the user's needs.
 ### Chaining / Pipelines
 
 Templates declare **input and output contracts** so they can be chained.
-Four pipelines are included:
+Four pipelines are defined in the manifest:
 
 **Document Lifecycle**
 
@@ -283,16 +283,7 @@ extract-rfc-requirements  →  evolve-protocol  →  author-protocol-validation 
                                protocol delta)      validation spec)                report)
 ```
 
-**Engineering Lifecycle** (the three workflows from [above](#the-engineering-lifecycle))
-
-```
-spec-extraction-workflow  →  engineering-workflow  →  maintenance-workflow
-  (bootstrap: extract        (evolve: propagate       (maintain: detect drift,
-   req / design / validation  changes with audits)      correct specs and code)
-   from existing repo)
-```
-
-The `engineering-workflow` pipeline itself chains five internal stages:
+**Engineering Workflow** (five internal stages)
 
 ```
 collaborate-requirements-change → generate-spec-changes → audit-spec-alignment
@@ -300,6 +291,9 @@ collaborate-requirements-change → generate-spec-changes → audit-spec-alignme
 ```
 
 The output of one template becomes the input parameter of the next.
+The [Engineering Lifecycle](#the-engineering-lifecycle) workflows
+(spec-extraction, engineering, maintenance) compose these pipelines
+into a higher-level lifecycle.
 
 ### Use Case: Specification Traceability Audit
 


### PR DESCRIPTION
## Summary

Refresh README to lead with the engineering lifecycle triad as the hero story and update all component counts/tables.

## What Changed

### New Hero Section: The Engineering Lifecycle

Added a prominent section with ASCII diagram showing the three-workflow cycle:

- **Bootstrap** (spec-extraction-workflow) -- scan any repo, extract structured specs
- **Evolve** (engineering-workflow) -- propagate changes with adversarial audits
- **Maintain** (maintenance-workflow) -- periodic drift detection and correction

### Updated Counts

| Component | Was | Now |
|-----------|-----|-----|
| Personas | 13 | 15 |
| Protocols | 44 | 48 |
| Formats | 20 | 21 |
| Templates | 54 | 64 |
| Pipelines | 3 | 4 |
| **Total** | **136** | **157** |

### New Entries Added to Tables

- **Personas**: rf-engineer, mechanical-engineer
- **Protocols**: change-propagation, step-retrospective, link-budget-audit, enclosure-design-review
- **Formats**: structured-patch
- **Templates**: 8 Engineering Workflow templates, review-enclosure, audit-link-budget
- **Pipelines**: engineering-workflow
