### PR TITLE
fix: add verbatim inclusion rule to bootstrap assembly instructions

### DIFF
--- a/bootstrap.md
+++ b/bootstrap.md
@@ -42,8 +42,10 @@ You are the **composition engine** for PromptKit. Your job is to:
    - If `mode` is absent or any other value — treat as **single-shot** and
      proceed to step 5b.
 5a. **Interactive mode**: Read the template's components (persona, protocols,
-   format) and include their full body text verbatim, then **execute the
-   template directly in this session**. Begin
+   and format if declared) and include their full body text verbatim, then
+   **execute the template directly in this session**. If the template
+   declares `format: null` or omits the format field, skip the format
+   component — do not include an `# Output Format` section. Begin
    the interactive workflow (e.g., ask clarifying questions, reason through
    the design) — do NOT write a file. Skip steps 5b–10.
 5b. **Single-shot mode**: Ask about the output mode before collecting
@@ -103,13 +105,18 @@ When assembling a prompt from components, follow this order:
 ### Verbatim Inclusion Rule
 
 The assembled prompt MUST contain the **complete body text** of every
-component, with only the following transformations allowed during assembly:
+component. When extracting a component's body text from its source file,
+only the following transformations are allowed:
 
 - Removal of YAML frontmatter (the `---`-delimited metadata block) and
   leading SPDX/HTML comment headers
 - Substitution of all `{{param}}` placeholders with user-provided values
 - Optional trimming of leading/trailing whitespace after frontmatter/comment
   stripping
+
+The overall assembled document adds section headers (`# Identity`,
+`# Reasoning Protocols`, etc.) and `---` separators between components —
+these are part of the assembly structure, not modifications to body text.
 
 Everything else — all rules, phases, examples, output format templates,
 known-safe patterns, checklists, and operational guidance — MUST be preserved


### PR DESCRIPTION
## Summary

Fixes #137 — bootstrap.md's assembly instructions caused LLMs to summarize and condense protocol content instead of including it verbatim, producing assembled prompts with as little as 6–7% of the source protocol content.

## Problem

The Assembly Process section used ambiguous language:
- **""Load the persona file""** — LLMs interpreted ""load"" as ""read and understand"" rather than ""copy the full text""
- **`<protocol 1 content>`** — interpreted as ""include the substance"" rather than ""transcribe verbatim""
- **""Contains condensed persona or protocol directives""** — although this only applied to agent-instructions output, the word ""condensed"" bled into the LLM's behavior for all output modes

Observed in eBPF for Windows workflow prompts where:
- Thread Safety and Security protocols were reduced to **phase headings only** (6–7% retention)
- Kernel Correctness was missing **all 7 known-safe patterns** (false-positive suppression rules)
- Self-Verification lost its **entire completeness gate checklist**
- Adversarial Falsification lost the **4-step disproof methodology**

## Changes

1. **Assembly steps**: ""Load"" → ""Read and include full body text verbatim"" for all component types
2. **New section**: ""Verbatim Inclusion Rule"" with explicit anti-summarization guidance and concrete examples
3. **Output template placeholders**: `<persona content>` → `<complete body of the persona file — verbatim, not summarized>`
4. **Scoped condensation**: ""condensed"" language now explicitly scoped to agent-instructions output mode only, with note that it never applies to raw prompt output

## Validation

- `python tests/validate-manifest.py` passes ✅
- No changes to CLI assembly code (`assemble.js` already handles this correctly via programmatic file concatenation)