### PR TITLE
fix(cli): pass bootstrap prompt to Claude and warn on CLI fallback

### DIFF
--- a/cli/lib/launch.js
+++ b/cli/lib/launch.js
@@ -54,7 +54,8 @@ function copyDirRecursive(src, dest) {
 }
 
 function launchInteractive(contentDir, cliName) {
-  const cli = cliName || detectCli();
+  const detected = detectCli();
+  const cli = cliName || detected;
 
   if (!cli) {
     console.error(
@@ -68,24 +69,35 @@ function launchInteractive(contentDir, cliName) {
     process.exit(1);
   }
 
+  // Warn the user when auto-detection chose a fallback CLI
+  if (!cliName && detected !== "copilot" && detected !== "gh-copilot") {
+    console.warn(
+      `Warning: GitHub Copilot CLI not found on PATH. ` +
+        `Falling back to '${cli}'.\n` +
+        `To use a specific CLI, pass --cli <name> (e.g., --cli copilot).\n`
+    );
+  }
+
   // Copy content to a temp directory so the LLM can read the files
   const tmpDir = copyContentToTemp(contentDir);
   console.log(`PromptKit content staged at: ${tmpDir}`);
   console.log(`Launching ${cli}...\n`);
 
+  const bootstrapPrompt = "Read and execute bootstrap.md";
+
   let cmd, args;
   switch (cli) {
     case "copilot":
       cmd = "copilot";
-      args = ["-i", "Read and execute bootstrap.md"];
+      args = ["-i", bootstrapPrompt];
       break;
     case "gh-copilot":
       cmd = "gh";
-      args = ["copilot", "-i", "Read and execute bootstrap.md"];
+      args = ["copilot", "-i", bootstrapPrompt];
       break;
     case "claude":
       cmd = "claude";
-      args = [];
+      args = [bootstrapPrompt];
       break;
     default:
       console.error(`Unknown CLI: ${cli}`);


### PR DESCRIPTION
## Fixes #140

Two bugs in `cli/lib/launch.js`:

### 1. Claude Code launched without bootstrap prompt

The `claude` case in the CLI switch passed empty args, so Claude opened a blank session. Fixed by passing the bootstrap prompt as a positional argument:

```diff
- case "claude":
-   cmd = "claude";
-   args = [];
+ case "claude":
+   cmd = "claude";
+   args = [bootstrapPrompt];
```

Claude Code accepts an initial prompt as a positional argument for interactive sessions, matching parity with Copilot's `-i` flag.

### 2. Silent fallback when Copilot not found

When `detectCli()` fell through to `claude` because Copilot wasn't on PATH, there was no user-facing indication. Fixed by emitting a `console.warn` when the auto-detected CLI is not `copilot` or `gh-copilot`:

```
Warning: GitHub Copilot CLI not found on PATH. Falling back to 'claude'.
To use a specific CLI, pass --cli <name> (e.g., --cli copilot).
```

### Testing

- Verified the fix produces correct spawn arguments for all three CLI paths
- The fallback warning only triggers during auto-detection (not when `--cli` is explicitly passed)