### PR TITLE
chore: release v0.5.0 — simplified CLI

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.3.0",
-  "description": "Composable prompt toolkit for software engineers. Assemble task-specific prompts from reusable personas, protocols, formats, and templates.",
+  "version": "0.5.0",
+  "description": "Composable prompt toolkit for software engineers. Launch an interactive LLM session to assemble task-specific prompts from reusable personas, protocols, formats, and templates.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release v0.5.0

Bumps CLI version to 0.5.0 for npm publish.

### ⚠️ Breaking Changes

- **Removed**: `assemble` command — prompt assembly is now handled entirely by the LLM via `bootstrap.md`
- **Removed**: `assemble.js` and `manifest.js` modules

### What's New

- **Verbatim Inclusion Rule** in `bootstrap.md` — prevents LLM from summarizing protocol content during assembly (#138)
- **24 automated tests** using Node.js built-in test runner, zero external dependencies (#149)
- **Simplified CLI** — two commands: `interactive` (default) + `list` (#145)
- **Dual content validation** — checks both `bootstrap.md` and `manifest.yaml` on startup
- **Improved error messages** — shows content directory path when no LLM CLI found

### Migration

If you were using `promptkit assemble`:
1. Run `promptkit` (interactive mode) and ask the LLM to assemble your prompt
2. Or load `bootstrap.md` directly in your LLM and follow the assembly process

`promptkit list` and `promptkit interactive` are unchanged.

### Test Results

```
ℹ tests 24 | pass 24 | fail 0
```