### PR TITLE
Add /bootstrap and /boot prompt file entry points

### DIFF
--- a/.github/prompts/boot.prompt.md
+++ b/.github/prompts/boot.prompt.md
@@ -2,24 +2,4 @@
 description: 'Start a new PromptKit prompt assembly session (alias for /bootstrap)'
 agent: 'agent'
 ---
-# Start a PromptKit Prompt Assembly Session
-
-## Goal
-
-Start a new PromptKit session by reading and executing the repository
-bootstrap instructions.
-
-## Instructions
-
-1. Read [bootstrap.md](../../bootstrap.md) in full.
-2. Execute the bootstrap instructions exactly as written.
-3. Use the bootstrap flow to identify the appropriate PromptKit
-   components and gather any required parameters.
-4. Assemble the resulting prompt according to the repository's
-   documented composition order.
-
-## Non-Goals
-
-- Do not bypass `bootstrap.md`.
-- Do not answer the user's task directly before executing the
-  bootstrap flow.
+Read and execute [bootstrap.md](../../bootstrap.md).

--- a/.github/prompts/bootstrap.prompt.md
+++ b/.github/prompts/bootstrap.prompt.md
@@ -2,24 +2,4 @@
 description: 'Start a new PromptKit prompt assembly session'
 agent: 'agent'
 ---
-# Start a PromptKit Prompt Assembly Session
-
-## Goal
-
-Start a new PromptKit session by reading and executing the repository
-bootstrap instructions.
-
-## Instructions
-
-1. Read [bootstrap.md](../../bootstrap.md) in full.
-2. Execute the bootstrap instructions exactly as written.
-3. Use the bootstrap flow to identify the appropriate PromptKit
-   components and gather any required parameters.
-4. Assemble the resulting prompt according to the repository's
-   documented composition order.
-
-## Non-Goals
-
-- Do not bypass `bootstrap.md`.
-- Do not answer the user's task directly before executing the
-  bootstrap flow.
+Read and execute [bootstrap.md](../../bootstrap.md).


### PR DESCRIPTION
Add `.github/prompts/` with two prompt files that invoke `bootstrap.md`:

- `bootstrap.prompt.md` -> `/bootstrap`
- `boot.prompt.md` -> `/boot`

Both are thin stubs referencing the real content at the repo root via relative Markdown link (`../../bootstrap.md`). This lets VS Code users type `/bootstrap` or `/boot` in Copilot Chat to start a prompt assembly session without needing to know the incantation.

Partial fix for #171 (`/init`, `/scaffold`, `/new` deferred to a follow-up).