### PR TITLE
Add pcb-layout-design reasoning protocol

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -533,7 +533,8 @@ protocols:
         a completed schematic. Covers layout requirements gathering,
         board definition, design rules, component placement, routing
         strategy, and automated execution via Python pcbnew API with
-        FreeRouting autorouter and KiCad DRC validation loop.
+        FreeRouting autorouter and KiCad DRC validation loop. Supports
+        2-layer and 4-layer stackups.
 
 formats:
   - name: requirements-doc

--- a/protocols/reasoning/pcb-layout-design.md
+++ b/protocols/reasoning/pcb-layout-design.md
@@ -324,8 +324,18 @@ the board setup, placement, and design rules from Phases 3–6.
    import pcbnew
    import sys
    
+   if len(sys.argv) != 2:
+       print("Usage: python3 layout.py path/to/board.kicad_pcb",
+             file=sys.stderr)
+       raise SystemExit(1)
+   
+   board_path = sys.argv[1]
+   
    # Load the board (must already have footprints/nets from schematic)
-   board = pcbnew.LoadBoard(sys.argv[1])
+   try:
+       board = pcbnew.LoadBoard(board_path)
+   except Exception as exc:
+       raise SystemExit(f"Failed to load board '{board_path}': {exc}")
    
    # --- Configuration (user-adjustable) ---
    BOARD_WIDTH_MM = ...


### PR DESCRIPTION
## Summary

Add a \pcb-layout-design\ reasoning protocol for PCB layout and routing from a completed schematic. This is Step 3 of 9 in building the end-to-end hardware design workflow. It is the generative counterpart to the existing \layout-design-review\ analysis protocol.

## New Components

| Type | Name | Path | Description |
|------|------|------|-------------|
| Protocol (reasoning) | pcb-layout-design | protocols/reasoning/pcb-layout-design.md | PCB layout via Python pcbnew API + FreeRouting + DRC loop |

## Design Decisions

- **Python pcbnew API, not raw .kicad_pcb**: PCB routing is a geometric optimization problem that LLMs cannot solve by generating trace coordinates directly. The protocol produces a Python script using KiCad's \pcbnew\ API for board setup and component placement, then delegates routing to FreeRouting (an open-source autorouter). This is deterministic, reviewable, and produces correct results.
- **Complete automated loop**: The protocol covers the full generate → route → validate → fix cycle: pcbnew placement → FreeRouting autorouting → \kicad-cli pcb drc\ validation → error classification → automated fix, with max 5 iterations before escalating to user.
- **Interactive requirements gathering**: Phase 2 explicitly gathers user spatial preferences (connector edge placement, MCU orientation, battery position, mechanical constraints) before any design decisions are made.
- **2-layer and 4-layer support**: Stackup definitions and routing strategies for both common configurations.
- **Fab house design rules**: Illustrative defaults for JLCPCB, PCBWay, and OSH Park with guidance to confirm against current specs.
- **Tool dependencies documented**: KiCad 7.0+, FreeRouting, Java, kicad-cli — with fallback behavior when tools are unavailable.
- **No new persona needed**: \lectrical-engineer\ covers the domain.
- **\pplicable_to: []\**: No template references this yet.

## Checklist

- [x] All files have SPDX license headers
- [x] YAML frontmatter is valid and complete
- [x] Component names match file names (kebab-case)
- [x] manifest.yaml updated with all new components
- [x] No vague instructions in protocols
- [x] Protocols have numbered, ordered phases
- [x] New components do not conflict with existing ones
- [x] CI validation passes (\python tests/validate-manifest.py\)