### PR TITLE
Add abbreviated mode to investigation-report format

### DIFF
--- a/formats/investigation-report.md
+++ b/formats/investigation-report.md
@@ -16,6 +16,18 @@ The output MUST be a structured investigation report. Use the **full
 format** by default. Use the **abbreviated format** when the conditions
 below are met.
 
+## Format Selection
+
+Before writing the report, **enumerate and classify all findings first**
+(count and highest severity). Then choose the format:
+
+- **Abbreviated**: finding count is 5 or fewer AND no Critical/High severity
+- **Full**: more than 5 findings, or any Critical/High, or incident
+  response / security audit context
+
+If the invoking template or workflow explicitly requires the full
+9-section structure, use the full format regardless of finding count.
+
 ## Abbreviated Format
 
 Use the abbreviated format when **both** conditions are true:
@@ -78,7 +90,10 @@ context where narrative and prevention matter.
 The full format MUST include the following sections in this exact order.
 Sections **1–8** are required. Section **9 (Revision History)** is
 included only when the report is maintained across revisions; if
-present, it MUST appear last. Omit §9 for single-pass automated audits.
+present, it MUST appear last. Omit §9 for single-pass automated audits
+unless the invoking template or workflow explicitly requires the full
+9-section structure — in that case, include §9 and state
+"Single-pass report; no prior revisions." when there is no history.
 
 ## Document Structure
 


### PR DESCRIPTION
Closes #112

## Summary

Add a conditional abbreviated format to `investigation-report` for routine, low-severity audits. Saves ~500-1000 response tokens per audit by omitting sections that add overhead without analytical value.

## Changes

- **Abbreviated format** (4 sections): Executive Summary, Findings, Remediation Plan, Coverage. Triggers when finding count is 5 or fewer AND no findings are Critical/High severity.
- **Section 9 (Revision History) marked optional**: Omit for single-pass automated audits.
- **Full format unchanged**: Still mandatory for incident response, security audits, and any investigation with >5 findings or Critical/High severity.
- **Auto-escalation**: If any finding is upgraded to Critical/High during investigation, switch to full format.

## Evidence (from issue)

Session profiling of three PromptKit audit prompts found ~500 response tokens (~15-25% of response) spent on formulaic sections (Problem Statement, Prevention, Revision History) in audits with only 3 low-severity findings.