### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alan-jowett/promptkit",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Composable prompt toolkit for software engineers. Launch an interactive LLM session to assemble task-specific prompts from reusable personas, protocols, formats, and templates.",
   "license": "MIT",
   "repository": {

--- a/cli/specs/requirements.md
+++ b/cli/specs/requirements.md
@@ -1,7 +1,7 @@
 ---
 title: "PromptKit CLI — Requirements Specification"
 project: "PromptKit CLI (@alan-jowett/promptkit)"
-version: "0.4.0"
+version: "0.6.0"
 date: "2026-03-31"
 status: draft
 source_files:

--- a/cli/specs/validation.md
+++ b/cli/specs/validation.md
@@ -1,7 +1,7 @@
 ---
 title: "PromptKit CLI — Validation Plan"
 project: "PromptKit CLI (@alan-jowett/promptkit)"
-version: "0.4.0"
+version: "0.6.0"
 date: "2026-03-31"
 status: draft
 related:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,7 +6,7 @@
 # The bootstrap prompt reads this manifest to discover available
 # personas, protocols, formats, and task templates.
 
-version: "0.4.0"
+version: "0.6.0"
 
 personas:
   - name: systems-engineer


### PR DESCRIPTION
## Summary

Bump all version numbers to 0.6.0 in preparation for tagging the v0.6.0 release.

## What's new in v0.6.0

### Hardware Design Workflow (new domain)
Complete end-to-end hardware design from idea to manufacturable PCB artifacts:

**New protocols (5)**:
- \component-selection\ — systematic component selection with real-time sourcing verification
- \component-selection-audit\ — adversarial audit catching hallucinated parts
- \schematic-design\ — KiCad schematic generation with visual layout rules
- \pcb-layout-design\ — automated PCB layout via Python pcbnew + FreeRouting + DRC loop
- \manufacturing-artifact-generation\ — Gerber/drill/BOM/PnP with fab-specific formatting

**New templates (4)**:
- \design-schematic\ — interactive schematic design with component selection + audits
- \design-pcb-layout\ — interactive PCB layout with schematic feedback loop
- \mit-manufacturing-artifacts\ — fab-ready deliverables for JLCPCB/PCBWay
- \hardware-design-workflow\ — end-to-end orchestrator (9 phases, 10 protocols)

**Pipeline**: \hardware-lifecycle\ extended from 5 audit-only stages to 8 interleaved design+audit stages

### Prompt Composition & Output Modes
- \copilot-prompt-file\ format — package prompts as \.prompt.md\ slash commands
- \gentic-workflow\ format — scheduled/event-driven GitHub Actions automations
- \decompose-prompt\ template + \prompt-decomposition\ protocol
- \udit-library-health\ template + \corpus-safety-audit\ protocol

### Presentation Authoring
- \uthor-presentation\ template with \presentation-kit\ format (python-pptx)

### CLI Improvements
- \/boot\, \/bootstrap\, \/promptkit\ CLI skills for zero-friction entry
- \list\, \search\, \show\ commands for component discovery
- Auto-generated \CATALOG.md\
- Custom agent and CLI skill targets in agent-instructions format

## Files changed

| File | Change |
|------|--------|
| manifest.yaml | 0.4.0 → 0.6.0 |
| cli/package.json | 0.5.0 → 0.6.0 |
| cli/package-lock.json | 0.5.0 → 0.6.0 |
| cli/specs/requirements.md | 0.4.0 → 0.6.0 |
| cli/specs/validation.md | 0.4.0 → 0.6.0 |