### PR TITLE
Fix CLI launch: remove shell: true from spawn

### DIFF
--- a/cli/lib/launch.js
+++ b/cli/lib/launch.js
@@ -116,7 +116,6 @@ function launchInteractive(contentDir, cliName) {
   const child = spawn(cmd, args, {
     cwd: originalCwd,
     stdio: "inherit",
-    shell: true,
   });
 
   child.on("error", (err) => {


### PR DESCRIPTION
## Problem

\
px @alan-jowett/promptkit\ fails with:

\\\
error: too many arguments. Expected 0 arguments but got 3.
\\\

Plus a Node deprecation warning:
\\\
(node:8212) [DEP0190] DeprecationWarning: Passing args to a child process
with shell option true can lead to security vulnerabilities
\\\

## Root Cause

\spawn(cmd, args, { shell: true })\ in \launch.js\ causes the shell to re-parse the args array. The bootstrap prompt string (\Read and execute /path/to/bootstrap.md\) contains spaces, so the shell splits it into multiple arguments. \copilot\ then receives \Read\, \nd\, \xecute\ as 3 separate args instead of the single \-i\ value.

## Fix

Remove \shell: true\. \spawn\ with an args array handles argument passing correctly without a shell intermediary — each element of the array becomes exactly one argument.

## Testing

Verified \
ode bin/cli.js --version\ still works after the change.