### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alan-jowett/promptkit",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alan-jowett/promptkit",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Composable prompt toolkit for software engineers. Launch an interactive LLM session to assemble task-specific prompts from reusable personas, protocols, formats, and templates.",
   "license": "MIT",
   "repository": {

--- a/cli/specs/requirements.md
+++ b/cli/specs/requirements.md
@@ -1,7 +1,7 @@
 ---
 title: "PromptKit CLI — Requirements Specification"
 project: "PromptKit CLI (@alan-jowett/promptkit)"
-version: "0.6.0"
+version: "0.6.1"
 date: "2026-03-31"
 status: draft
 source_files:

--- a/cli/specs/validation.md
+++ b/cli/specs/validation.md
@@ -1,7 +1,7 @@
 ---
 title: "PromptKit CLI — Validation Plan"
 project: "PromptKit CLI (@alan-jowett/promptkit)"
-version: "0.6.0"
+version: "0.6.1"
 date: "2026-03-31"
 status: draft
 related:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -6,7 +6,7 @@
 # The bootstrap prompt reads this manifest to discover available
 # personas, protocols, formats, and task templates.
 
-version: "0.6.0"
+version: "0.6.1"
 
 personas:
   - name: systems-engineer


### PR DESCRIPTION
Hotfix release: fixes CLI launch failure caused by \shell: true\ in spawn (#197).