### PR TITLE
fix: add falsification discipline to security audit template

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1351,7 +1351,7 @@ templates:
         Security audit of code or a system component. Systematic
         vulnerability analysis with severity classification.
       persona: security-auditor
-      protocols: [anti-hallucination, self-verification, operational-constraints, security-vulnerability]
+      protocols: [anti-hallucination, self-verification, operational-constraints, adversarial-falsification, security-vulnerability]
       taxonomies: [stack-lifetime-hazards]
       format: investigation-report
 

--- a/protocols/analysis/security-vulnerability.md
+++ b/protocols/analysis/security-vulnerability.md
@@ -61,8 +61,12 @@ For every external input:
    - Initialization-time invariants — constructor or init functions
      that constrain values to safe ranges (e.g., power-of-2
      requirements, maximum bounds)
-   Do NOT report a finding until you have confirmed that no upstream
-   validation neutralizes it.
+   Do NOT report a finding until you have explicitly documented:
+   - Which upstream validators, contracts, and invariants you checked
+   - The evidence or source for any API postconditions you relied on
+     (e.g., vendor documentation, manpage, or header annotations)
+   - Why each checked item does not neutralize the candidate
+     vulnerability in this code path
 
 ## Phase 3: Authentication and Authorization
 

--- a/protocols/analysis/security-vulnerability.md
+++ b/protocols/analysis/security-vulnerability.md
@@ -48,6 +48,21 @@ For every external input:
    re-encoded, decoded, or transformed before use.
 4. Check for **integer overflow/underflow** in size or length parameters
    derived from external input.
+5. **Validation provenance check**: For every candidate vulnerability at
+   a use site, trace **backward** to find all validation that may have
+   occurred between the input's entry and the use. Check:
+   - Caller functions that decode or validate before passing values
+     (e.g., a header-decode helper that checks `Field > MaxAllowed`
+     before the caller uses `Field` in arithmetic)
+   - Helper functions called earlier in the same code path
+   - API postconditions — when a system API (e.g., kernel API, stdlib)
+     returns success, what guarantees does it make about output buffer
+     contents, lengths, or value ranges?
+   - Initialization-time invariants — constructor or init functions
+     that constrain values to safe ranges (e.g., power-of-2
+     requirements, maximum bounds)
+   Do NOT report a finding until you have confirmed that no upstream
+   validation neutralizes it.
 
 ## Phase 3: Authentication and Authorization
 

--- a/protocols/guardrails/self-verification.md
+++ b/protocols/guardrails/self-verification.md
@@ -38,10 +38,12 @@ presenting it as final. Treat it as a pre-submission checklist.
   the same type** before proceeding.
 - For each sampled finding, apply **symmetric falsification**: attempt
   to disprove the finding with the same rigor you applied when
-  falsifying candidate findings that you concluded were safe. Ask:
-  "Is there a validation, API contract, or initialization invariant
-  I missed that makes this safe?" If you cannot answer "no" with
-  specific code evidence, downgrade or remove the finding.
+  falsifying candidate findings that you concluded were safe. Verify
+  whether any upstream validation, API contract, or initialization
+  invariant makes this safe; cite the specific call sites, checks, or
+  invariants reviewed and explain why they do not neutralize the
+  finding. If you have not verified that upstream validation does not
+  apply, downgrade or remove the finding.
 
 ### 2. Citation Audit
 

--- a/protocols/guardrails/self-verification.md
+++ b/protocols/guardrails/self-verification.md
@@ -36,6 +36,12 @@ presenting it as final. Treat it as a pre-submission checklist.
   - Does the evidence actually support the conclusion stated?
 - If any sampled item fails verification, **re-examine all items of
   the same type** before proceeding.
+- For each sampled finding, apply **symmetric falsification**: attempt
+  to disprove the finding with the same rigor you applied when
+  falsifying candidate findings that you concluded were safe. Ask:
+  "Is there a validation, API contract, or initialization invariant
+  I missed that makes this safe?" If you cannot answer "no" with
+  specific code evidence, downgrade or remove the finding.
 
 ### 2. Citation Audit
 

--- a/protocols/reasoning/exhaustive-path-tracing.md
+++ b/protocols/reasoning/exhaustive-path-tracing.md
@@ -11,6 +11,7 @@ description: >
 applicable_to:
   - review-code
   - investigate-bug
+  - investigate-security
   - exhaustive-bug-hunt
 ---
 

--- a/templates/investigate-security.md
+++ b/templates/investigate-security.md
@@ -12,6 +12,7 @@ protocols:
   - guardrails/anti-hallucination
   - guardrails/self-verification
   - guardrails/operational-constraints
+  - guardrails/adversarial-falsification
   - analysis/security-vulnerability
 taxonomies:
   - stack-lifetime-hazards

--- a/templates/investigate-security.md
+++ b/templates/investigate-security.md
@@ -14,6 +14,7 @@ protocols:
   - guardrails/operational-constraints
   - guardrails/adversarial-falsification
   - analysis/security-vulnerability
+  - reasoning/exhaustive-path-tracing  # optional — apply selectively to parser/decoder functions
 taxonomies:
   - stack-lifetime-hazards
 format: investigation-report
@@ -89,6 +90,42 @@ code or system component.
    - Prefer deterministic methods (targeted search, structured enumeration)
    - Document your search strategy for reproducibility
 
+7. **Apply the exhaustive-path-tracing protocol selectively** to
+   **parser and decoder functions** that process untrusted structured input.
+   This protocol is not applied to every function — only to functions
+   identified during Phase 2 (attack surface enumeration) that meet
+   ALL of the following criteria:
+
+   - The function **decodes multiple fields** from a wire format, file
+     format, or serialized structure controlled by an untrusted source
+   - The function **performs arithmetic** (subtraction, addition,
+     multiplication, shift) on two or more decoded values, or between
+     a decoded value and a running accumulator
+   - The function contains **loops** that iterate over a variable number
+     of decoded elements, where each iteration updates shared state
+     (offsets, remaining lengths, accumulators)
+
+   For each such function, apply the full exhaustive-path-tracing
+   protocol with particular attention to:
+
+   - **Inter-value arithmetic validation**: After decoding a new field
+     value, verify that every subsequent arithmetic operation using that
+     value against a running accumulator (e.g., `Largest -= Count`) is
+     guarded against underflow or overflow — not just at the decode site,
+     but at every use site within the function, including the *current*
+     loop iteration (not just the next iteration's entry check).
+   - **Loop-carried invariant gaps**: When a loop body decodes a fresh
+     value and uses it immediately, but the bounds check for that value
+     only runs at the *next* iteration's entry, the current iteration's
+     use is unguarded. Explicitly verify that each decoded value is
+     validated before its first arithmetic use within the same iteration.
+   - **Truncation after bounds check**: When a decoded uint64_t value
+     passes a bounds check against a uint16_t buffer length and is then
+     cast to uint16_t, the cast is safe. But when a decoded value is
+     used in arithmetic *without* a prior bounds check against the
+     current accumulator, the arithmetic may underflow even though the
+     decode itself succeeded.
+
 ## Non-Goals
 
 Explicitly define what is OUT OF SCOPE for this security audit.
@@ -111,10 +148,19 @@ Before beginning analysis, produce a concrete step-by-step plan:
    data enters the system.
 2. **Enumerate attack surface**: List every input handling path,
    authentication point, and privilege transition.
-3. **Classify**: Apply the security-vulnerability protocol systematically
+3. **Identify parser/decoder functions for deep analysis**: From the
+   attack surface enumeration, identify functions that decode multiple
+   fields from untrusted structured input and perform inter-value
+   arithmetic (see instruction 7). List these functions explicitly —
+   they will receive exhaustive path tracing.
+4. **Classify**: Apply the security-vulnerability protocol systematically
    to each attack surface element.
-4. **Rank**: Order findings by exploitability and impact.
-5. **Report**: Produce the output according to the specified format.
+5. **Deep-dive**: Apply the exhaustive-path-tracing protocol to each
+   function identified in step 3. For each, trace every arithmetic
+   operation on decoded values through every loop iteration and
+   verify underflow/overflow guards exist at every use site.
+6. **Rank**: Order findings by exploitability and impact.
+7. **Report**: Produce the output according to the specified format.
 
 ## Quality Checklist
 
@@ -128,3 +174,6 @@ Before finalizing, verify:
 - [ ] At least 3 findings have been re-verified against the source
 - [ ] Coverage statement documents what was and was not examined
 - [ ] No fabricated vulnerabilities — unknowns marked with [UNKNOWN]
+- [ ] All parser/decoder functions identified in step 3 have coverage
+      ledgers from exhaustive-path-tracing (or explicit justification
+      for skipping)


### PR DESCRIPTION
## Summary

Add adversarial falsification discipline to the security audit workflow to reduce false positive findings. Three targeted changes to the `investigate-security` template and its protocols, motivated by a real-world audit where 2 of 9 findings were false positives due to missed upstream validation.

## Problem

During a security audit of a protocol implementation, the audit produced false positives because:

1. **Incomplete provenance tracing**: A finding reported an integer underflow at a use site, but an upstream caller function already validated the constraint. The audit analyzed the arithmetic in isolation without tracing back to the validation origin.

2. **Missing API contract analysis**: A finding reported a heap overflow via `memcpy` with an unchecked length, but the length came from `ZwQueryValueKey` which *guarantees* the output fits within the provided buffer on success. The audit treated an API output as untrusted input.

Both failures share a root cause: the audit applied falsification rigor asymmetrically — more rigorously to "this looks safe" conclusions (6 correctly falsified) than to "this looks dangerous" conclusions (2 false positives reported).

## Changes

| # | Component | Change | Prevents |
|---|-----------|--------|----------|
| 1 | `templates/investigate-security.md` | Add `guardrails/adversarial-falsification` to protocol list | Requires "disprove before reporting" and "verify helpers and callers" — directly catches upstream validation in caller functions |
| 2 | `protocols/analysis/security-vulnerability.md` | Add **validation provenance check** (Phase 2, step 5) — backward tracing from use site to validation origin | Forces checking caller validation, API postconditions, and init-time invariants before reporting |
| 3 | `protocols/guardrails/self-verification.md` | Add **symmetric falsification** to Sampling Verification (Rule 1) | Breaks confirmation bias by requiring equal falsification rigor for "dangerous" and "safe" conclusions |
| 4 | `manifest.yaml` | Sync protocol list for `investigate-security` | Consistency with template frontmatter |

## Design Decisions

- **Reused `adversarial-falsification` protocol** — it already contains the exact rules needed (Rule 2: "Disprove Before Reporting", Rule 4: "Verify Helpers and Callers"). The template simply wasn't including it.
- **Added backward tracing to `security-vulnerability`** rather than creating a new protocol — the step is specific to input validation audit (Phase 2) and extends the existing forward-tracing methodology.
- **Added symmetric falsification to `self-verification`** — this is a cross-cutting guardrail change that benefits all templates, not just security audits. The language is minimal and scoped to the sampling verification step.

## Checklist

- [x] All files have SPDX license headers
- [x] YAML frontmatter is valid and complete
- [x] Component names match file names (kebab-case)
- [x] manifest.yaml updated with all new components
- [x] No vague instructions in protocols or templates
- [x] Templates have a quality checklist section
- [x] New components do not conflict with existing ones