### PR TITLE
Fix investigate-security protocol mismatch breaking CI

### DIFF
--- a/templates/investigate-security.md
+++ b/templates/investigate-security.md
@@ -14,7 +14,7 @@ protocols:
   - guardrails/operational-constraints
   - guardrails/adversarial-falsification
   - analysis/security-vulnerability
-  - reasoning/exhaustive-path-tracing  # optional — apply selectively to parser/decoder functions
+  - reasoning/exhaustive-path-tracing
 taxonomies:
   - stack-lifetime-hazards
 format: investigation-report

--- a/tests/validate-graph-integrity.py
+++ b/tests/validate-graph-integrity.py
@@ -79,10 +79,8 @@ def _parse_template_frontmatter(text: str) -> dict[str, object] | None:
             # Still collect multi-line list items at indent 2
             if current_list_field and stripped.startswith("- "):
                 val = stripped[2:].strip().strip("'\"")
-                # Strip inline YAML comments
-                comment_match = re.match(r"^([^#]+?)\s+#", val)
-                if comment_match:
-                    val = comment_match.group(1).strip().strip("'\"")
+                # Strip inline YAML comments only when `#` follows whitespace
+                val = re.split(r"\s+#", val, maxsplit=1)[0].strip().strip("'\"")
                 result[current_list_field].append(val)
             elif stripped and current_list_field and not stripped.startswith("#"):
                 current_list_field = None

--- a/tests/validate-graph-integrity.py
+++ b/tests/validate-graph-integrity.py
@@ -78,9 +78,12 @@ def _parse_template_frontmatter(text: str) -> dict[str, object] | None:
         if indent > 0:
             # Still collect multi-line list items at indent 2
             if current_list_field and stripped.startswith("- "):
-                result[current_list_field].append(
-                    stripped[2:].strip().strip("'\"")
-                )
+                val = stripped[2:].strip().strip("'\"")
+                # Strip inline YAML comments
+                comment_match = re.match(r"^([^#]+?)\s+#", val)
+                if comment_match:
+                    val = comment_match.group(1).strip().strip("'\"")
+                result[current_list_field].append(val)
             elif stripped and current_list_field and not stripped.startswith("#"):
                 current_list_field = None
             continue

--- a/tests/validate-manifest.py
+++ b/tests/validate-manifest.py
@@ -47,7 +47,12 @@ def parse_yaml_frontmatter(text: str) -> dict[str, object] | None:
             continue
         if in_protocols:
             if stripped.startswith("- "):
-                protocols.append(stripped[2:].strip().strip("'\""))
+                val = stripped[2:].strip().strip("'\"")
+                # Strip inline YAML comments
+                comment_match = re.match(r"^([^#]+?)\s+#", val)
+                if comment_match:
+                    val = comment_match.group(1).strip().strip("'\"")
+                protocols.append(val)
             else:
                 in_protocols = False
     return {"protocols": protocols}

--- a/tests/validate-manifest.py
+++ b/tests/validate-manifest.py
@@ -48,10 +48,8 @@ def parse_yaml_frontmatter(text: str) -> dict[str, object] | None:
         if in_protocols:
             if stripped.startswith("- "):
                 val = stripped[2:].strip().strip("'\"")
-                # Strip inline YAML comments
-                comment_match = re.match(r"^([^#]+?)\s+#", val)
-                if comment_match:
-                    val = comment_match.group(1).strip().strip("'\"")
+                # Strip inline YAML comments only when '#' is preceded by whitespace.
+                val = re.split(r"\s+#", val, maxsplit=1)[0].strip().strip("'\"")
                 protocols.append(val)
             else:
                 in_protocols = False


### PR DESCRIPTION
## Problem

CI is failing on both `validate-manifest.py` and `validate-graph-integrity.py` because the `investigate-security` template frontmatter contains an inline YAML comment that the lightweight parsers don't strip:

```yaml
- reasoning/exhaustive-path-tracing  # optional — apply selectively to parser/decoder functions
```

The parsers treat the entire line (including the comment) as the protocol name, causing mismatches.

## Fix

1. **`templates/investigate-security.md`** — Removed the inline comment (the information is already documented in the template body at lines 93-94)
2. **`tests/validate-manifest.py`** — Added inline comment stripping for multi-line list items
3. **`tests/validate-graph-integrity.py`** — Same hardening

## Validation

Both `python tests/validate-manifest.py` and `python tests/validate-graph-integrity.py` pass after this change.