### PR TITLE
fix: restore em-dash characters corrupted to ??? in launch tests

### DIFF
--- a/cli/tests/launch.test.js
+++ b/cli/tests/launch.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// cli/tests/launch.test.js ??? Launch module unit tests
+// cli/tests/launch.test.js — Launch module unit tests
 
 const { describe, it, before, after } = require("node:test");
 const assert = require("node:assert");
@@ -46,7 +46,7 @@ describe("Launch Module", () => {
   before(() => {
     assert.ok(
       fs.existsSync(contentDir),
-      "content/ must exist ??? run 'npm run prepare' first"
+      "content/ must exist — run 'npm run prepare' first"
     );
   });
 
@@ -257,7 +257,7 @@ describe("Launch Module", () => {
         .join("\n");
       assert.ok(
         !/\bshell\s*:\s*true\b/.test(nonCommentLines),
-        "launch.js must not pass shell: true to spawn() ??? doing so splits the bootstrap prompt into multiple arguments"
+        "launch.js must not pass shell: true to spawn() — doing so splits the bootstrap prompt into multiple arguments"
       );
     });
   });
@@ -331,7 +331,7 @@ describe("Launch Module", () => {
     }
 
     for (const cliName of ["claude", "copilot", "gh-copilot", "codex"]) {
-      // TC-CLI-082 and TC-CLI-083 combined ??? run once per CLI
+      // TC-CLI-082 and TC-CLI-083 combined — run once per CLI
       it(`TC-CLI-082/083: ${cliName} spawned with originalCwd and --add-dir for staging dir`, () => {
         const mockBinDir = path.join(cwdTestTmpDir, `mock-bin-${cliName}`);
         fs.mkdirSync(mockBinDir, { recursive: true });


### PR DESCRIPTION
PR #238 introduced encoding corruption where em-dash characters (`—`) were replaced with `???` in four locations in `cli/tests/launch.test.js`. This restores the original Unicode em-dash (U+2014) characters.

### Changes
- Line 2: comment header
- Line 49: assertion message
- Line 260: assertion message
- Line 334: comment

All four are cosmetic string fixes — no logic changes.